### PR TITLE
Исправлена ошибка формирования окончаний функцией getCountEnding()

### DIFF
--- a/translations/others/scripts/quest/paramtext.lua
+++ b/translations/others/scripts/quest/paramtext.lua
@@ -4,9 +4,10 @@ function itemShortDescription(itemDescriptor)
 end
 
 local function getCountEnding(count)
-  local residue = count % 10
-  if count > 10 and count < 21 then return ""
-  elseif resudue == 1 then return "а"
+  local residue = math.abs(count) % 100
+  if residue > 10 and residue < 20 then return "" end
+  residue = residue % 10
+  if residue == 1 then return "а"
   elseif residue > 1 and residue < 5 then return "и"
   else return "" end
 end


### PR DESCRIPTION
### Описание
Помимо обращения к несуществующей переменной `resudue` исправлена ошибка формирования окончания в случаях, когда переданное число больше 100.

Даже если исправить только опечатку, окончания формировались неверно.

### Примеры

**в оригинале** (с исправленной опечаткой): 211 штука
**после патча**: 211 штук

**в оригинале** (с исправленной опечаткой): -324 штук
**после патча**: -324 штуки

Онлайн пример работы кода: https://ideone.com/szEolE